### PR TITLE
Clean case logic

### DIFF
--- a/pyepic/applications/zopt.py
+++ b/pyepic/applications/zopt.py
@@ -16,7 +16,7 @@ class ExameshStep(JobStep):
         toml_file,
         partitions=1,
         execute_step=True,
-        clean_case=True
+        clean_case=False
     ):
         super().__init__()
         self.step_name = "ExaMesh"
@@ -101,9 +101,10 @@ class ZOPTJob(Job):
         cycles=100,
         restart=False,
         partitions=1,
+        clean_case=False
     ):
         super().__init__(zcfd_version, job_name, data_path)
-        self.examesh = ExameshStep(toml_file, partitions=1)
+        self.examesh = ExameshStep(toml_file, partitions=1, clean_case=clean_case)
         self.add_step(self.examesh)
         self.zcfd = ZCFDStep(
             case_name,

--- a/pyepic/client/job.py
+++ b/pyepic/client/job.py
@@ -87,7 +87,7 @@ class JobClient(Client):
             if limit < get_batch_size:
                 get_batch_size = limit
             instance = epiccore.JobApi(api_client)
-            results = instance.job_list(job_array=str(job_array), limit=get_batch_size, offset=offset)
+            results = instance.job_list(limit=get_batch_size, offset=offset)
             for result in results.results:
                 count += 1
                 yield result


### PR DESCRIPTION
Adding a temp fix for job_array not working, exposing the clean_case logic to the full zOpt class